### PR TITLE
linearisation de l'ex vocal

### DIFF
--- a/src/main/java/fr/cringebot/cringe/xp/XP.java
+++ b/src/main/java/fr/cringebot/cringe/xp/XP.java
@@ -47,7 +47,7 @@ public class XP {
     }
 
     private static Long calcul(Long time){
-        double d = Math.pow(time, 2)/ 12960000000L;
+        double d = time/3600;
         return Math.round(d);
     }
 }


### PR DESCRIPTION
c'est pour eviter un ecart entre le gain max par textuelle au bout de d'un moment par rapport au vocal